### PR TITLE
Decouple config file from message_tagging_service module

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include README.md LICENSE
-include rules/*.yaml
+include rules/*.yaml tests/data/* conf/*.py fedmsg.d/*.py

--- a/conf/config.py
+++ b/conf/config.py
@@ -47,9 +47,3 @@ class DevConfiguration(BaseConfiguration):
         'org.fedoraproject.dev.mbs.build.state.change'
         'org.fedoraproject.stg.mbs.build.state.change'
     ]
-
-
-if 'MTS_DEV' in os.environ:
-    mts_conf = DevConfiguration()
-else:
-    mts_conf = BaseConfiguration()

--- a/message_tagging_service/__init__.py
+++ b/message_tagging_service/__init__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Message tagging service is an event-driven service to tag build.
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Chenxiong Qi <cqi@redhat.com>
+
+import message_tagging_service.config
+
+conf = message_tagging_service.config.load_config()

--- a/message_tagging_service/messaging.py
+++ b/message_tagging_service/messaging.py
@@ -22,7 +22,7 @@
 import logging
 import json
 
-from message_tagging_service.mts_config import mts_conf
+from message_tagging_service import conf
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ def publish(topic, msg):
     :param dict msg: the message contents of the message (typically JSON)
     :return: the value returned from underlying backend "send" method.
     """
-    backend = mts_conf.messaging_backend
+    backend = conf.messaging_backend
     try:
         handler = _messaging_backends[backend]['publish']
     except KeyError:
@@ -46,8 +46,8 @@ def publish(topic, msg):
 def _fedmsg_publish(topic, msg):
     # fedmsg doesn't really need access to conf, however other backends do
     import fedmsg
-    config = mts_conf.messaging_backends['fedmsg']
-    if mts_conf.dry_run:
+    config = conf.messaging_backends['fedmsg']
+    if conf.dry_run:
         logger.info('DRY-RUN: fedmsg.publish(%s, msg=%s, modname=%s)',
                     topic, msg, config['service'])
     else:
@@ -64,7 +64,7 @@ def _rhmsg_publish(topic, msg):
     import proton
     from rhmsg.activemq.producer import AMQProducer
 
-    config = mts_conf.messaging_backends['rhmsg']
+    config = conf.messaging_backends['rhmsg']
     producer_config = {
         'urls': config['brokers'],
         'certificate': config['certificate'],
@@ -78,7 +78,7 @@ def _rhmsg_publish(topic, msg):
 
         outgoing_msg = proton.Message()
         outgoing_msg.body = json.dumps(msg)
-        if mts_conf.dry_run:
+        if conf.dry_run:
             logger.info('DRY-RUN: AMQProducer.send(%s) through topic %s',
                         outgoing_msg, topic)
         else:

--- a/message_tagging_service/tagging_service.py
+++ b/message_tagging_service/tagging_service.py
@@ -29,7 +29,7 @@ import yaml
 from operator import truth
 
 from message_tagging_service import messaging
-from message_tagging_service.mts_config import mts_conf
+from message_tagging_service import conf
 from message_tagging_service.utils import retrieve_modulemd_content
 
 logger = logging.getLogger(__name__)
@@ -288,12 +288,12 @@ def tag_build(nvr, dest_tags):
     :rtype: list[str]
     """
     tagged_tags = []
-    koji_config = koji.read_config(mts_conf.koji_profile)
+    koji_config = koji.read_config(conf.koji_profile)
     koji_session = koji.ClientSession(koji_config['server'])
     koji_session.krb_login()
     for tag in dest_tags:
         try:
-            if mts_conf.dry_run:
+            if conf.dry_run:
                 logger.info('DRY-RUN: koji_session.tagBuild(%s, %s)', tag, nvr)
             else:
                 koji_session.tagBuild(tag, nvr)

--- a/message_tagging_service/utils.py
+++ b/message_tagging_service/utils.py
@@ -23,7 +23,7 @@ import koji
 import requests
 import yaml
 
-from message_tagging_service.mts_config import mts_conf
+from message_tagging_service import conf
 
 
 def retrieve_modulemd_content(name, stream, version, context):
@@ -36,7 +36,7 @@ def retrieve_modulemd_content(name, stream, version, context):
     :return: modulemd content.
     :rtype: str
     """
-    koji_config = koji.read_config(mts_conf.koji_profile)
+    koji_config = koji.read_config(conf.koji_profile)
     url = (f'{koji_config["topurl"]}/{name}/{stream}/{version}.{context}'
            f'/files/module/modulemd.txt')
     resp = requests.get(url)
@@ -51,5 +51,5 @@ def read_rule_defs():
         a mapping.
     :rtype: dict
     """
-    with open(mts_conf.rule_file, 'r') as f:
+    with open(conf.rule_file, 'r') as f:
         return yaml.safe_load(f)

--- a/tests/data/config.py
+++ b/tests/data/config.py
@@ -1,0 +1,3 @@
+class BaseConfiguration(object):
+    dry_run = True
+    test = True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# Message tagging service is an event-driven service to tag build.
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Chenxiong Qi <cqi@redhat.com>
+
+import os
+
+from mock import patch
+from message_tagging_service import config
+
+test_config = os.path.join(os.path.dirname(__file__),
+                           'data',
+                           'config.py')
+
+
+class TestGetConfigFile(object):
+
+    @patch.dict('os.environ', values={'MTS_CONFIG_FILE': test_config})
+    def test_use_specified_config_file(self):
+        conf = config.load_config()
+        assert conf.test
+
+    @patch.dict('os.environ', values={'MTS_DEV': '1'})
+    def test_use_config_from_source_code(self):
+        conf = config.load_config()
+        assert 'DevConfiguration' == conf.__class__.__name__
+
+    @patch.dict('os.environ', clear=True)
+    @patch.object(config, 'running_tests', new=False)
+    @patch('importlib.machinery')
+    def test_use_installed_config(self, machinery):
+        conf = config.load_config()
+
+        machinery.SourceFileLoader.assert_called_once_with(
+            'mts_conf',
+            '/etc/mts/config.py')
+
+        loader = machinery.SourceFileLoader.return_value
+        mod = loader.load_module.return_value
+        assert conf == mod.BaseConfiguration.return_value

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -33,8 +33,8 @@ except ImportError:
 
 class TestMessaging(object):
 
-    @patch.object(messaging.mts_conf, 'messaging_backend', new='fedmsg')
-    @patch.dict(messaging.mts_conf.messaging_backends, values={'fedmsg': {
+    @patch.object(messaging.conf, 'messaging_backend', new='fedmsg')
+    @patch.dict(messaging.conf.messaging_backends, values={'fedmsg': {
         'service': 'myapp'
     }})
     @patch('fedmsg.publish')
@@ -45,8 +45,8 @@ class TestMessaging(object):
             'build.tagged', msg={'build_id': 1}, modname='myapp')
 
     @pytest.mark.skipif(not rhmsg, reason='Library rhmsg is not available.')
-    @patch.object(messaging.mts_conf, 'messaging_backend', new='rhmsg')
-    @patch.dict(messaging.mts_conf.messaging_backends, values={'rhmsg': {
+    @patch.object(messaging.conf, 'messaging_backend', new='rhmsg')
+    @patch.dict(messaging.conf.messaging_backends, values={'rhmsg': {
         'topic_prefix': 'VirtualTopic.eng.mts.',
         'brokers': ['amqps://broker1/', 'amqps://broker2/'],
         'certificate': '/path/to/certificate',
@@ -72,7 +72,7 @@ class TestMessaging(object):
         Message.return_value.body = json.dumps(msg)
         producer.send.assert_called_once_with(Message.return_value)
 
-    @patch.object(messaging.mts_conf, 'messaging_backend', new='anothercool')
+    @patch.object(messaging.conf, 'messaging_backend', new='anothercool')
     def test_no_backend_handler_is_found(self):
         with pytest.raises(KeyError):
             messaging.publish('topic', {})

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -137,7 +137,7 @@ data:
 '''
 
         rule_file = os.path.join(test_data_dir, 'mts-test-for-no-match.yaml')
-        with patch.object(tagging_service.mts_conf, 'rule_file', new=rule_file):
+        with patch.object(tagging_service.conf, 'rule_file', new=rule_file):
             rule_defs = read_rule_defs()
 
         with patch.object(tagging_service.logger, 'info') as info:
@@ -177,7 +177,7 @@ data:
 '''
 
         rule_file = os.path.join(test_data_dir, 'mts-test-rules.yaml')
-        with patch.object(tagging_service.mts_conf, 'rule_file', new=rule_file):
+        with patch.object(tagging_service.conf, 'rule_file', new=rule_file):
             rule_defs = read_rule_defs()
             tagging_service.handle(rule_defs, {
                 'id': 1,
@@ -221,7 +221,7 @@ data:
 '''
 
         rule_file = os.path.join(test_data_dir, 'mts-test-rules.yaml')
-        with patch.object(tagging_service.mts_conf, 'rule_file', new=rule_file):
+        with patch.object(tagging_service.conf, 'rule_file', new=rule_file):
             rule_defs = read_rule_defs()
             tagging_service.handle(rule_defs, {
                 'id': 1,


### PR DESCRIPTION
This change makes it possible to install config file into /etc/mts/, and
load config for development and production.

If MTS_DEV is defined in environment variables, loading config from
conf/config.py, otherwise loading from /etc/mts/config.py.

There is another choice to overwrite both of them, that is to define
MTS_CONFIG_FILE which should point to an existing Python file including
configuration class.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>