### PR TITLE
Better log when module build in init state

### DIFF
--- a/message_tagging_service/consumer.py
+++ b/message_tagging_service/consumer.py
@@ -42,8 +42,9 @@ class MTSConsumer(fedmsg.consumers.FedmsgConsumer):
 
         event_msg = msg['body']['msg']
         if event_msg['state_name'] != 'ready':
-            logger.info('Skip module build %s as it is not in ready state yet.',
-                        event_msg['koji_tag'])
+            logger.info('Skip module build %s-%s-%s-%s as it is not in ready state yet.',
+                        event_msg['name'], event_msg['stream'],
+                        event_msg['version'], event_msg['context'])
             return
 
         try:

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -53,8 +53,12 @@ class TestConsumer(object):
     def test_ignore_message_if_not_ready(self, handle, read_rule_defs):
         consumer = self.new_consumer()
         consumer.consume({'body': {'msg': {
-            'state_name': 'done',
-            'koji_tag': 'module-modulea-1-1-c1',
+            'name': 'modulea',
+            'stream': '10',
+            'version': '201902141503',
+            'context': '00000000',
+            'state_name': 'init',
+            'koji_tag': None,
         }}})
 
         handle.assert_not_called()


### PR DESCRIPTION
When a module build in init state, koji_tag is just None. Original log
message logs "Skip module build None ...", which does not make sense and
hard to know which module build is skipped if DEBUG log level is
disabled. Instead, this patch construct module NSVC explicitly inside
log message.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>