### PR TITLE
Expose metrics endpoint for monitoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN dnf install -y \
         python3-qpid-proton \
         python3-rhmsg \
         krb5-workstation \
+        python3-gunicorn
     && dnf clean all
 
 RUN sed -i '/default_ccache_name = KEYRING:persistent:%{uid}/d' /etc/krb5.conf
@@ -43,4 +44,5 @@ VOLUME /etc/mts
 # Mount to a directory holding the fedmsg config file(s)
 VOLUME /etc/fedmsg.d
 USER 1001
-CMD ["/usr/bin/bash", "-c", "docker/install-ca.sh && exec fedmsg-hub-3"]
+EXPOSE 8080
+ENTRYPOINT ["docker/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+script_dir=$(dirname $(realpath $0))
+
+$script_dir/install-ca.sh && exec fedmsg-hub-3 &
+gunicorn-3 -b 0.0.0.0:8080 message_tagging_service.web:app

--- a/message_tagging_service/monitor.py
+++ b/message_tagging_service/monitor.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#
+# Message tagging service is an event-driven service to tag build.
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Original authors: Filip Valder
+
+# Copied from https://pagure.io/monitor-flask-sqlalchemy/blob/master/f/monitor.py
+# Customized for MTS, e.g. database metrics are removed because MTS does not
+# uses a database.
+
+import os
+import tempfile
+
+from prometheus_client import CollectorRegistry
+from prometheus_client import ProcessCollector
+from prometheus_client import multiprocess
+from prometheus_client import Counter
+from prometheus_client import generate_latest
+
+if not os.environ.get('prometheus_multiproc_dir'):
+    dir_name = tempfile.mkdtemp(prefix='mts-prometheus-multiproc-')
+    os.environ.setdefault('prometheus_multiproc_dir', dir_name)
+
+registry = CollectorRegistry()
+ProcessCollector(registry=registry)
+multiprocess.MultiProcessCollector(registry)
+
+failed_tag_build_requests_counter = Counter(
+    'failed_tag_build_requests',
+    'The number of failed tagBuild API calls.',
+    registry=registry
+)
+
+matched_module_builds_counter = Counter(
+    'matched_module_builds',
+    'The number of module builds which are matched rule(s) to be tagged.',
+    registry=registry
+)
+
+messages_notify_errors_counter = Counter(
+    'messages_notify_errors',
+    'The number of errors occurred during sending message to bus.',
+    registry=registry
+)
+
+
+def generate_metrics_report():
+    return generate_latest(registry)

--- a/message_tagging_service/tagging_service.py
+++ b/message_tagging_service/tagging_service.py
@@ -31,8 +31,9 @@ import yaml
 from collections import namedtuple
 from contextlib import contextmanager
 
-from message_tagging_service import messaging
 from message_tagging_service import conf
+from message_tagging_service import messaging
+from message_tagging_service import monitor
 from message_tagging_service.utils import retrieve_modulemd_content
 
 logger = logging.getLogger(__name__)
@@ -359,6 +360,7 @@ def tag_build(nvr, dest_tags, koji_session):
         except Exception as e:
             tagged_tags.append(
                 TagBuildResult(tag_name=tag, task_id=None, error=str(e)))
+            monitor.failed_tag_build_requests_counter.inc()
         else:
             tagged_tags.append(
                 TagBuildResult(tag_name=tag, task_id=task_id, error=None))
@@ -407,6 +409,8 @@ def handle(rule_defs, event_msg):
             },
         })
         return
+
+    monitor.matched_module_builds_counter.inc()
 
     stream = this_stream.replace('-', '_')
     with make_koji_session() as koji_session:

--- a/message_tagging_service/web.py
+++ b/message_tagging_service/web.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# Message tagging service is an event-driven service to tag build.
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Chenxiong Qi <cqi@redhat.com>
+
+from flask import Flask, Response
+from prometheus_client import CONTENT_TYPE_LATEST
+
+from message_tagging_service.monitor import generate_metrics_report
+
+app = Flask(__name__)
+
+
+@app.route('/', methods=['GET'])
+def index():
+    return Response('Welcome to Message-Tagging-Service (aka MTS)')
+
+
+@app.route('/monitor/metrics', methods=['GET'])
+def metrics():
+    return Response(generate_metrics_report(),
+                    content_type=CONTENT_TYPE_LATEST)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+Flask
 PyYAML
 fedmsg
 koji
@@ -5,4 +6,5 @@ moksha.hub
 psutil
 python-qpid-proton
 requests
+prometheus_client
 # rhmsg is not available in PyPI so far.


### PR DESCRIPTION
This metrics endpoint is for expose data for Prometheus.

The docker image executes fedmsg-hub in background and expose 8080 for HTTP
requests.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>