### PR TITLE
Add missing \ to break dnf-install command properly in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN dnf install -y \
         python3-qpid-proton \
         python3-rhmsg \
         krb5-workstation \
-        python3-gunicorn
+        python3-gunicorn \
     && dnf clean all
 
 RUN sed -i '/default_ccache_name = KEYRING:persistent:%{uid}/d' /etc/krb5.conf


### PR DESCRIPTION
Signed-off-by: Chenxiong Qi <cqi@redhat.com>