### PR TITLE
Set gunicorn log level to debug

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,4 +3,4 @@
 script_dir=$(dirname $(realpath $0))
 
 $script_dir/install-ca.sh && exec fedmsg-hub-3 &
-gunicorn-3 -b 0.0.0.0:8080 message_tagging_service.web:app
+gunicorn-3 --log-level debug -b 0.0.0.0:8080 message_tagging_service.web:app


### PR DESCRIPTION
This is for debugging MTS in Openshift, which reports error "worker timeout".

Signed-off-by: Chenxiong Qi <cqi@redhat.com>