### PR TITLE
Enlarge gunicorn worker timeout

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,4 +3,4 @@
 script_dir=$(dirname $(realpath $0))
 
 $script_dir/install-ca.sh && exec fedmsg-hub-3 &
-gunicorn-3 --log-level debug -b 0.0.0.0:8080 --workers 4 message_tagging_service.web:app
+gunicorn-3 --log-level debug -b 0.0.0.0:8080 --timeout 300 --graceful-timeout 300 message_tagging_service.web:app


### PR DESCRIPTION
This patch also removes --workers to just launch one worker.

In some environment, after container is up, WORKER TIMEOUT critical logs are
printed frequently, and new workers are created and launched again and again.
But, HTTP GET request inside container can still succeed, although it is slow
and usually takes minutes to finish. This change aims to avoid destroying and
booting new workers frequently.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>