### PR TITLE
Adjust gunicorn command line options

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,4 +3,4 @@
 script_dir=$(dirname $(realpath $0))
 
 $script_dir/install-ca.sh && exec fedmsg-hub-3 &
-gunicorn-3 --log-level debug -b 0.0.0.0:8080 --workers 4 message_tagging_service.web:app
+gunicorn-3 --log-level ${GUNICORN_LOG_LEVEL:-info} -b 0.0.0.0:8080 message_tagging_service.web:app


### PR DESCRIPTION
* Restore to use just 1 worker as MTS web endpoint is simple enough to response
  GET request and return data from memory.
* Make log level configurable by environment variable.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>