### PR TITLE
Reduce the number of tries to match rules

### DIFF
--- a/tests/data/mts-test-rules.yaml
+++ b/tests/data/mts-test-rules.yaml
@@ -18,6 +18,20 @@
       development: no
   destinations: '\g<platform>-modular-ursamajor'
 
+- id: Tag for done state
+  description: Gating builds
+  type: module
+  rule:
+      dependencies:
+          buildrequires:
+              platform: '^.*$'
+          requires:
+              platform: '^(?P<platform>f\d+)$'
+      scratch: no
+      development: no
+      build_state: done
+  destinations: '\g<platform>-modular-gating'
+
 - id: Modular Python for Fedora
   description: Python Fedora modular builds
   type: module


### PR DESCRIPTION
The worst case is when a module build with state build comes in, there is no
rule defined for this state, which probably only has rules for state done and
ready. In this case, MTS will try to test the module build with every rule.

With this patch, the build state is checked before starting to match rules. And
rules with same build state are checked only, others with different build state
are skipped.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>