### PR TITLE
Change the metric name to be in sync with other services

### DIFF
--- a/message_tagging_service/messaging.py
+++ b/message_tagging_service/messaging.py
@@ -43,7 +43,7 @@ def publish(topic, msg):
     try:
         return handler(topic, msg)
     except Exception:
-        monitor.messages_notify_errors_counter.inc()
+        monitor.messaging_tx_failed_counter.inc()
         logger.exception('Failed to send message to topic %s: %s', topic, msg)
 
 

--- a/message_tagging_service/monitor.py
+++ b/message_tagging_service/monitor.py
@@ -52,8 +52,8 @@ matched_module_builds_counter = Counter(
     registry=registry
 )
 
-messages_notify_errors_counter = Counter(
-    'messages_notify_errors',
+messaging_tx_failed_counter = Counter(
+    'messaging_tx_failed',
     'The number of errors occurred during sending message to bus.',
     registry=registry
 )


### PR DESCRIPTION
This is to be able to catch `messaging_tx_failed` in monitoring/alerting/graphing for MTS, as it already works "by magic" for the rest of our services.

Without this, we'd have to do some relabeling or create a special alert for it etc.