### PR TITLE
Install packages for Fedora container

### DIFF
--- a/docker/install-dependencies.sh
+++ b/docker/install-dependencies.sh
@@ -18,6 +18,7 @@ dependencies=(
     python3-gunicorn
     python3-flask
     python3-prometheus_client
+    krb5-workstation
 )
 
 if [ -n "$rcm_tools_repos" ]; then
@@ -28,6 +29,8 @@ if [ -n "$rcm_tools_repos" ]; then
     sed -i 's/https:/http:/g' $repo_file
 
     dependencies+=(python3-rhmsg)
+else
+    dependencies+=(fedora-packager koji)
 fi
 
 dnf install -y \

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -509,7 +509,7 @@ class TestLoginKoji(object):
         session.getAPIVersion.return_value = 1
 
         with pytest.raises(
-                IOError, message='SSL certificate path/to/cert is not readable.'):
+                IOError, match='SSL certificate path/to/cert is not readable.'):
             tagging_service.login_koji(session, {
                 'authtype': 'kerberos',
                 'serverca': '',


### PR DESCRIPTION
fedora-packager provides config files for Koji and Kerberos
authentication, which could make it a little bit easier to deploy MTS in
Fedora.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>