### PR TITLE
Run mts in the foreground

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 script_dir=$(dirname $(realpath $0))
 
-$script_dir/install-ca.sh && python3 -m message_tagging_service &
-gunicorn-3 --log-level ${GUNICORN_LOG_LEVEL:-info} -b 0.0.0.0:8080 message_tagging_service.web:app
+$script_dir/install-ca.sh
+gunicorn-3 --log-level ${GUNICORN_LOG_LEVEL:-info} -b 0.0.0.0:8080 message_tagging_service.web:app &
+exec python3 -m message_tagging_service


### PR DESCRIPTION
The message_tagging_service runs as a python module. In the container
image, gunicorn is also run for prometheus metrics. This is a secondary
capability of the container image. The most important being the python
process that run MTS. By making it run in the foreground,
OpenShift/Kubernetes can properly determine if the pod needs to be
restarted in case MTS quits unexpectedly.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>