### PR TITLE
Upgrade base image to Fedora 31

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:29
+FROM registry.fedoraproject.org/fedora:31
 
 LABEL maintainer="Factory 2 Team" \
       description="A microservice triggered by specific message to tag a build." \

--- a/docker/install-dependencies.sh
+++ b/docker/install-dependencies.sh
@@ -12,6 +12,7 @@ dependencies=(
     python3-gunicorn
     python3-koji
     python3-qpid-proton
+    python3-pip
     python3-prometheus_client
     python3-pyyaml
     python3-requests


### PR DESCRIPTION
Also explicitly install python3-pip, as it's not part of the Fedora
image anymore.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>