### PR TITLE
Do not handle scratch build

### DIFF
--- a/message_tagging_service/tagging_service.py
+++ b/message_tagging_service/tagging_service.py
@@ -217,7 +217,13 @@ class RuleDef(object):
             # Both scratch and development have default value to compare with
             # expected in rule definition.
 
-            if property in ('development', 'scratch'):
+            if property == 'scratch':
+                logger.warning(
+                    'Ignore rule "scratch: %s" which is removed from rule '
+                    'definition specification already.', expected)
+                continue
+
+            if property in ['development']:
                 mmd_value = modulemd["data"].get(property, False)
                 if expected == mmd_value:
                     logger.debug('Rule/Value: %s: %s. Matched.', property, expected)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -50,26 +50,6 @@ class TestRuleDefinitionCheck(object):
         assert match
         assert ['modular-fallback-tag'] == match.dest_tags
 
-    def test_match_scratch_module_build(self):
-        rule_def = {
-            'id': 'Simple match by scratch',
-            'type': 'module',
-            'rule': {'scratch': True},
-            'description': 'Match module build by scratch.',
-            'destinations': 'modular-fallback-tag'
-        }
-
-        modulemd = {'data': {'scratch': True}}
-        match = tagging_service.RuleDef(rule_def).match(modulemd)
-        assert match
-        assert ['modular-fallback-tag'] == match.dest_tags
-
-        modulemd = {'data': {'scratch': False}}
-        assert not tagging_service.RuleDef(rule_def).match(modulemd)
-
-        modulemd = {'data': {}}
-        assert not tagging_service.RuleDef(rule_def).match(modulemd)
-
     def test_match_development_module_build(self):
         rule_def = {
             'id': 'Simple match by development',


### PR DESCRIPTION
In this PR, MTS ignores `scratch: xxx` if it appears in a rule definition, and ignore the message of a scratch module build.