### PR TITLE
Fallback to fedora:30 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:31
+FROM registry.fedoraproject.org/fedora:30
 
 LABEL maintainer="Factory 2 Team" \
       description="A microservice triggered by specific message to tag a build." \


### PR DESCRIPTION
rcm-tools-repo does not have fedora 31 support for now.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>