### PR TITLE
Use image fedora:31 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 - docker
 
 before_install:
-- docker pull registry.fedoraproject.org/fedora:29
+- docker pull registry.fedoraproject.org/fedora:31
 
 install: true
 
@@ -12,12 +12,13 @@ jobs:
   include:
   - stage: Tests
     script: |
-      docker run --rm -v $(pwd):/code:Z -i -t registry.fedoraproject.org/fedora:29 /bin/bash -c "
-      dnf install -y python36 python3-devel python3-detox gcc redhat-rpm-config rpm-devel krb5-devel
+      docker run --rm -v $(pwd):/code:Z -i -t registry.fedoraproject.org/fedora:31 /bin/bash -c "
+      dnf install -y python36 python3-devel gcc redhat-rpm-config rpm-devel krb5-devel
+      python3 -m venv /root/testenv
+      source /root/testenv
       cd /code
-      python3 -m venv .env
-      .env/bin/pip install tox
-      .env/bin/tox
+      python3 -m pip install tox
+      python3 -m tox
       "
   - stage: "Test image build and container"
     script:


### PR DESCRIPTION
Image registry.fedoraproject.org/fedora:29 is not available, that breaks
CI at the step of "docker pull".

Signed-off-by: Chenxiong Qi <cqi@redhat.com>