### PR TITLE
consumer: only receive msgs with build_state is ready or done by default

### DIFF
--- a/conf/config.py
+++ b/conf/config.py
@@ -62,6 +62,10 @@ class BaseConfiguration:
     # tagged if no build state is specified in rule explicitly.
     build_state = 'ready'
 
+    # Default build state filter for the messages sent by MBS. This happens
+    # before any rules applied. Default: ['ready', 'done']
+    build_state_msg_filter = ['ready', 'done']
+
 
 class DevConfiguration(BaseConfiguration):
     koji_profile = 'stg'

--- a/message_tagging_service/config.py
+++ b/message_tagging_service/config.py
@@ -40,7 +40,9 @@ class Config:
     Setting a new value to instance['name'] will override the value of property
         (but only for this particular instance)
     """
-    _defaults = {}
+    _defaults = {
+        'build_state_msg_filter': ['ready', 'done']
+    }
 
     def __init__(self, profile=None, config_file=None, config_class=None):
         """

--- a/message_tagging_service/consumer.py
+++ b/message_tagging_service/consumer.py
@@ -77,6 +77,11 @@ def consume(msg):
         logger.warning('Ignore scratch build %s', mbs_msg)
         return
 
+    build_state = mbs_msg.get('build_state')
+    if build_state not in conf.build_state_msg_filter:
+        logger.warning('The message with build_state: %s is ignored.', build_state)
+        return
+
     try:
         rule_defs = read_rule_defs()
     except requests.exceptions.HTTPError:

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -125,6 +125,7 @@ class TestConsumer(object):
         'stream': '2.7',
         'version': '1',
         'context': 'c1',
+        'build_state': 'ready',
     }, {}])
     @patch('message_tagging_service.consumer.tagging_service.handle')
     @patch('requests.get')
@@ -186,7 +187,8 @@ class TestConsumer(object):
             'name': 'modulea',
             'stream': '10',
             'version': '20200107111030',
-            'context': 'c1'
+            'context': 'c1',
+            'build_state': 'ready',
         })
 
         with patch.object(consumer, 'logger') as logger:
@@ -225,3 +227,12 @@ class TestConsumer(object):
             consumer.consume(msg)
             args, _ = logger.warning.call_args
             assert 'Ignore scratch build' in args[0]
+
+    def test_ignore_filtered_out_by_states(self):
+        msg = fedora_messaging.api.Message(body={'name': 'modulea',
+                                                 'build_state': 'init'})
+
+        with patch.object(consumer, 'logger') as logger:
+            consumer.consume(msg)
+            args, _ = logger.warning.call_args
+            assert 'The message with build_state:' in args[0]


### PR DESCRIPTION
This is to have a "whitelist" of `build_state` which only allows "ready", "done" builds' msg to proceed with rules by default config